### PR TITLE
Add ClassDeclSyntax+AccessLevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ xcuserdata/
 *.dSYM.zip
 *.dSYM
 
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
 # Swift Package Manager
 Packages/
 Package.pins

--- a/Sources/SwiftSyntaxSugar/ClassDeclSyntax/ClassDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/ClassDeclSyntax/ClassDeclSyntax+AccessLevel.swift
@@ -1,0 +1,16 @@
+//
+//  ClassDeclSyntax+AccessLevel.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 11/4/23.
+//
+
+import SwiftSyntax
+
+extension ClassDeclSyntax {
+
+    /// The class declaration's access level.
+    public var accessLevel: AccessLevelSyntax {
+        self.modifiers.accessLevel
+    }
+}

--- a/Tests/SwiftSyntaxSugarTests/ClassDeclSyntax/ClassDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ClassDeclSyntax/ClassDeclSyntax_AccessLevelTests.swift
@@ -1,0 +1,41 @@
+//
+//  ClassDeclSyntax_AccessLevelTests.swift
+//  SwiftSyntaxSugarTests
+//
+//  Created by Gray Campbell on 11/4/23.
+//
+
+import SwiftSyntax
+import XCTest
+
+@testable import SwiftSyntaxSugar
+
+final class ClassDeclSyntax_AccessLevelTests: XCTestCase {
+
+    // MARK: Typealiases
+
+    typealias SUT = ClassDeclSyntax
+
+    // MARK: Access Level Tests
+
+    func testAccessLevelWithExplicitAccessLevels() {
+        for accessLevel in AccessLevelSyntax.allCases {
+            let modifiers = DeclModifierListSyntax {
+                accessLevel.modifier
+                DeclModifierSyntax(name: .keyword(.final))
+            }
+            let sut = SUT(modifiers: modifiers, name: "SUT") {}
+
+            XCTAssertEqual(sut.accessLevel, accessLevel)
+        }
+    }
+
+    func testAccessLevelWithImplicitInternalAccessLevel() {
+        let modifiers = DeclModifierListSyntax {
+            DeclModifierSyntax(name: .keyword(.final))
+        }
+        let sut = SUT(modifiers: modifiers, name: "SUT") {}
+
+        XCTAssertEqual(sut.accessLevel, .internal)
+    }
+}


### PR DESCRIPTION
# Summary
- Added `ClassDeclSyntax+AccessLevel` to `SwiftSyntaxSugar`.
- Added `ClassDeclSyntax_AccessLevelTests` to `SwiftSyntaxSugarTests`.