### PR TITLE
Add FunctionTypeSyntax+Escaping

### DIFF
--- a/Sources/SwiftSyntaxSugar/FunctionTypeSyntax/FunctionTypeSyntax+Escaping.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionTypeSyntax/FunctionTypeSyntax+Escaping.swift
@@ -1,0 +1,28 @@
+//
+//  FunctionTypeSyntax+Escaping.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 11/4/23.
+//
+
+import SwiftSyntax
+
+extension FunctionTypeSyntax {
+
+    /// Returns an escaping version of the function type.
+    ///
+    /// - Returns: An escaping version of the function type.
+    public func escaping() -> AttributedTypeSyntax {
+        AttributedTypeSyntax(
+            attributes: AttributeListSyntax {
+                AttributeSyntax(
+                    atSign: .atSignToken(),
+                    attributeName: IdentifierTypeSyntax(
+                        name: .keyword(.escaping)
+                    )
+                )
+            },
+            baseType: self
+        )
+    }
+}

--- a/Tests/SwiftSyntaxSugarTests/FunctionTypeSyntax/FunctionTypeSyntax_EscapingTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionTypeSyntax/FunctionTypeSyntax_EscapingTests.swift
@@ -1,0 +1,32 @@
+//
+//  FunctionTypeSyntax_EscapingTests.swift
+//  SwiftSyntaxSugarTests
+//
+//  Created by Gray Campbell on 11/4/23.
+//
+
+import SwiftSyntax
+import XCTest
+
+@testable import SwiftSyntaxSugar
+
+final class FunctionTypeSyntax_EscapingTests: XCTestCase {
+
+    // MARK: Typealiases
+
+    typealias SUT = FunctionTypeSyntax
+
+    // MARK: Escaping Tests
+
+    func testEscaping() {
+        let sut = SUT(
+            parameters: TupleTypeElementListSyntax(),
+            returnClause: ReturnClauseSyntax(type: .bool)
+        )
+
+        XCTAssertEqual(
+            sut.escaping().description,
+            "@escaping()->Bool"
+        )
+    }
+}


### PR DESCRIPTION
# Summary
- Added `FunctionTypeSyntax+Escaping` to `SwiftSyntaxSugar`.
- - Added `FunctionTypeSyntax_EscapingTests` to `SwiftSyntaxSugarTests`.