### PR TITLE
Add InheritedTypeListSyntax+IdentifierTypes

### DIFF
--- a/Sources/SwiftSyntaxSugar/InheritedTypeListSyntax/InheritedTypeListSyntax+IdentifierTypes.swift
+++ b/Sources/SwiftSyntaxSugar/InheritedTypeListSyntax/InheritedTypeListSyntax+IdentifierTypes.swift
@@ -1,0 +1,18 @@
+//
+//  InheritedTypeListSyntax+IdentifierTypes.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 11/4/23.
+//
+
+import SwiftSyntax
+
+extension InheritedTypeListSyntax {
+
+    /// The list's `IdentifierTypeSyntax` inherited types.
+    public var identifierTypes: [IdentifierTypeSyntax] {
+        self.compactMap { inheritedType in
+            inheritedType.type.as(IdentifierTypeSyntax.self)
+        }
+    }
+}

--- a/Tests/SwiftSyntaxSugarTests/InheritedTypeListSyntax/InheritedTypeListSyntax_IdentifierTypesTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/InheritedTypeListSyntax/InheritedTypeListSyntax_IdentifierTypesTests.swift
@@ -1,0 +1,36 @@
+//
+//  InheritedTypeListSyntax_IdentifierTypesTests.swift
+//  SwiftSyntaxSugarTests
+//
+//  Created by Gray Campbell on 11/4/23.
+//
+
+import SwiftSyntax
+import XCTest
+
+@testable import SwiftSyntaxSugar
+
+final class InheritedTypeListSyntax_IdentifierTypesTests: XCTestCase {
+
+    // MARK: Typealiases
+
+    typealias SUT = InheritedTypeListSyntax
+
+    // MARK: Identifier Types Tests
+
+    func testIdentifierTypes() {
+        let sut = SUT {
+            InheritedTypeSyntax(
+                type: IdentifierTypeSyntax(name: "Hashable")
+            )
+            InheritedTypeSyntax(
+                type: IdentifierTypeSyntax(name: "Identifiable")
+            )
+        }
+
+        XCTAssertEqual(
+            sut.identifierTypes.map(\.name.text),
+            ["Hashable", "Identifiable"]
+        )
+    }
+}


### PR DESCRIPTION
# Summary
- Added `InheritedTypeListSyntax+IdentifierTypes` to `SwiftSyntaxSugar`.
- Added `InheritedTypeListSyntax_IdentifierTypesTests` to `SwiftSyntaxSugarTests`.