### PR TITLE
Add VariableDeclSyntax+AccessLevel

### DIFF
--- a/Sources/SwiftSyntaxSugar/VariableDeclSyntax/VariableDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/VariableDeclSyntax/VariableDeclSyntax+AccessLevel.swift
@@ -1,0 +1,46 @@
+//
+//  VariableDeclSyntax+AccessLevel.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 11/4/23.
+//
+
+import SwiftSyntax
+
+extension VariableDeclSyntax {
+
+    /// The variable declaration's access level.
+    public var accessLevel: AccessLevelSyntax {
+        self.modifiers.accessLevel
+    }
+
+    /// Returns a copy of the variable declaration with the provided access
+    /// level.
+    ///
+    /// - Parameter accessLevel: The access level of the new variable
+    ///   declaration.
+    /// - Returns: A copy of the variable declaration with the provided access
+    ///   level.
+    public func withAccessLevel(
+        _ accessLevel: AccessLevelSyntax
+    ) -> VariableDeclSyntax {
+        let modifiers = DeclModifierListSyntax {
+            if accessLevel != .internal {
+                accessLevel.modifier
+            }
+
+            for modifier in self.modifiers where !modifier.isAccessLevel {
+                modifier
+            }
+        }
+
+        return VariableDeclSyntax(
+            leadingTrivia: self.leadingTrivia,
+            attributes: self.attributes,
+            modifiers: modifiers,
+            bindingSpecifier: self.bindingSpecifier,
+            bindings: self.bindings,
+            trailingTrivia: self.trailingTrivia
+        )
+    }
+}

--- a/Tests/SwiftSyntaxSugarTests/VariableDeclSyntax/VariableDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/VariableDeclSyntax/VariableDeclSyntax_AccessLevelTests.swift
@@ -1,0 +1,81 @@
+//
+//  VariableDeclSyntax_AccessLevelTests.swift
+//  SwiftSyntaxSugarTests
+//
+//  Created by Gray Campbell on 11/4/23.
+//
+
+import SwiftSyntax
+import XCTest
+
+@testable import SwiftSyntaxSugar
+
+final class VariableDeclSyntax_AccessLevelTests: XCTestCase {
+
+    // MARK: Typealiases
+
+    typealias SUT = VariableDeclSyntax
+
+    // MARK: Access Level Tests
+
+    func testAccessLevelWithExplicitAccessLevels() {
+        for accessLevel in AccessLevelSyntax.allCases {
+            let sut = SUT(
+                modifiers: DeclModifierListSyntax { accessLevel.modifier },
+                .var,
+                name: "sut"
+            )
+
+            XCTAssertEqual(sut.accessLevel, accessLevel)
+        }
+    }
+
+    func testAccessLevelWithImplicitInternalAccessLevel() {
+        let sut = SUT(.var, name: "sut")
+
+        XCTAssertEqual(sut.accessLevel, .internal)
+    }
+
+    // MARK: With Access Level Tests
+
+    func testWithAccessLevelWithExplicitAccessLevels() {
+        for oldAccessLevel in AccessLevelSyntax.allCases {
+            for newAccessLevel in AccessLevelSyntax.allCases {
+                let sut = SUT(
+                    modifiers: DeclModifierListSyntax {
+                        oldAccessLevel.modifier
+                        DeclModifierSyntax(name: .keyword(.static))
+                    },
+                    .var,
+                    name: "sut"
+                )
+                .withAccessLevel(newAccessLevel)
+
+                XCTAssertEqual(sut.accessLevel, newAccessLevel)
+                XCTAssertEqual(
+                    sut.modifiers.count,
+                    newAccessLevel == .internal ? 1 : 2
+                )
+            }
+        }
+    }
+
+    func testWithAccessLevelWithImplicitInternalAccessLevel() {
+        for newAccessLevel in AccessLevelSyntax.allCases {
+            let sut = SUT(
+                modifiers: DeclModifierListSyntax {
+                    DeclModifierSyntax(name: .keyword(.static))
+                },
+                .var,
+                name: "sut"
+            )
+            .withAccessLevel(newAccessLevel)
+
+            XCTAssertEqual(sut.accessLevel, newAccessLevel)
+            XCTAssertEqual(
+                sut.modifiers.count,
+                newAccessLevel == .internal ? 1 : 2
+            )
+        }
+    }
+}


### PR DESCRIPTION
# Summary
- Added `VariableDeclSyntax+AccessLevel` to `SwiftSyntaxSugar`.
- Added `VariableDeclSyntax_AccessLevelTests` to `SwiftSyntaxSugarTests`.