### PR TITLE
Replace optional array types with non-optional arrays

### DIFF
--- a/Sources/SwiftSyntaxSugar/AccessorDeclSyntax/AccessorDeclSyntax+Effects.swift
+++ b/Sources/SwiftSyntaxSugar/AccessorDeclSyntax/AccessorDeclSyntax+Effects.swift
@@ -20,7 +20,7 @@ extension AccessorDeclSyntax {
     }
 
     /// The keywords needed to invoke the accessor (i.e. `try` and/or `await`).
-    public var invocationKeywordTokens: [TokenSyntax]? {
+    public var invocationKeywordTokens: [TokenSyntax] {
         var keywordTokens: [TokenSyntax] = []
 
         if self.isThrowing {
@@ -31,6 +31,6 @@ extension AccessorDeclSyntax {
             keywordTokens.append(.keyword(.await))
         }
 
-        return keywordTokens.isEmpty ? nil : keywordTokens
+        return keywordTokens
     }
 }

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Effects.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Effects.swift
@@ -20,7 +20,7 @@ extension FunctionDeclSyntax {
     }
 
     /// The keywords needed to invoke the function (i.e. `try` and/or `await`).
-    public var invocationKeywordTokens: [TokenSyntax]? {
+    public var invocationKeywordTokens: [TokenSyntax] {
         var keywordTokens: [TokenSyntax] = []
 
         if self.isThrowing {
@@ -31,6 +31,6 @@ extension FunctionDeclSyntax {
             keywordTokens.append(.keyword(.await))
         }
 
-        return keywordTokens.isEmpty ? nil : keywordTokens
+        return keywordTokens
     }
 }

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Parameters.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Parameters.swift
@@ -17,14 +17,8 @@ extension FunctionDeclSyntax {
     /// func increase(by increment: Int, limit: Int)
     /// ```
     /// the parameter variable names would be `increment` and `limit`.
-    public var parameterVariableNames: [TokenSyntax]? {
-        let parameters = self.signature.parameterClause.parameters
-
-        guard !parameters.isEmpty else {
-            return nil
-        }
-
-        return parameters.map { parameter in
+    public var parameterVariableNames: [TokenSyntax] {
+        self.signature.parameterClause.parameters.map { parameter in
             parameter.secondName ?? parameter.firstName
         }
     }

--- a/Tests/SwiftSyntaxSugarTests/AccessorDeclSyntax/AccessorDeclSyntax_EffectsTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/AccessorDeclSyntax/AccessorDeclSyntax_EffectsTests.swift
@@ -88,7 +88,7 @@ final class AccessorDeclSyntax_EffectsTests: XCTestCase {
     func testInvocationKeywordTokensWithNilAsyncAndThrowsSpecifiers() {
         let sut = SUT(accessorSpecifier: .keyword(.get))
 
-        XCTAssertNil(sut.invocationKeywordTokens)
+        XCTAssertTrue(sut.invocationKeywordTokens.isEmpty)
     }
 
     func testInvocationKeywordTokensWithNonNilAsyncAndThrowsSpecifiers() throws {

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_EffectsTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_EffectsTests.swift
@@ -140,7 +140,7 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertNil(sut.invocationKeywordTokens)
+        XCTAssertTrue(sut.invocationKeywordTokens.isEmpty)
     }
 
     func testInvocationKeywordTokensWithNonNilAsyncAndThrowsSpecifiers() throws {
@@ -172,6 +172,6 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertNil(sut.invocationKeywordTokens)
+        XCTAssertTrue(sut.invocationKeywordTokens.isEmpty)
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ParametersTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ParametersTests.swift
@@ -25,7 +25,7 @@ final class FunctionDeclSyntax_ParametersTests: XCTestCase {
             )
         )
 
-        XCTAssertNil(sut.parameterVariableNames)
+        XCTAssertTrue(sut.parameterVariableNames.isEmpty)
     }
 
     func testParameterVariableNamesWithNonEmptyParameters() throws {


### PR DESCRIPTION
# Summary
- Made `AccessorDeclSyntax.invocationKeywordTokens` non-optional. 
- Made `FunctionDeclSyntax.invocationKeywordTokens` non-optional.
- Made `FunctionDeclSyntax.parameterVariableNames` non-optional.
- Updated unit tests.