### PR TITLE
Add FunctionDeclSyntax+Modifiers

### DIFF
--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+AccessLevel.swift
@@ -32,17 +32,6 @@ extension FunctionDeclSyntax {
             }
         }
 
-        return FunctionDeclSyntax(
-            leadingTrivia: self.leadingTrivia,
-            attributes: self.attributes,
-            modifiers: modifiers,
-            funcKeyword: self.funcKeyword,
-            name: self.name,
-            genericParameterClause: self.genericParameterClause,
-            signature: self.signature,
-            genericWhereClause: self.genericWhereClause,
-            body: self.body,
-            trailingTrivia: self.trailingTrivia
-        )
+        return self.withModifiers(modifiers)
     }
 }

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Body.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Body.swift
@@ -35,7 +35,8 @@ extension FunctionDeclSyntax {
     ///   function declaration.
     /// - Returns: A copy of the function declaration with the provided body.
     public func withBody(
-        @CodeBlockItemListBuilder bodyBuilder: @escaping () throws -> CodeBlockItemListSyntax?
+        @CodeBlockItemListBuilder 
+        bodyBuilder: @escaping () throws -> CodeBlockItemListSyntax?
     ) throws -> FunctionDeclSyntax {
         try FunctionDeclSyntax(
             leadingTrivia: self.leadingTrivia,

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Modifiers.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Modifiers.swift
@@ -1,0 +1,48 @@
+//
+//  FunctionDeclSyntax+Modifiers.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 7/17/24.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension FunctionDeclSyntax {
+
+    // MARK: With Modifiers
+
+    /// Returns a copy of the function declaration with the provided modifiers.
+    ///
+    /// - Parameter modifiers: The modifiers of the new function declaration.
+    /// - Returns: A copy of the function declaration with the provided
+    ///   modifiers.
+    public func withModifiers(
+        _ modifiers: DeclModifierListSyntax
+    ) -> FunctionDeclSyntax {
+        FunctionDeclSyntax(
+            leadingTrivia: self.leadingTrivia,
+            attributes: self.attributes,
+            modifiers: modifiers,
+            funcKeyword: self.funcKeyword,
+            name: self.name,
+            genericParameterClause: self.genericParameterClause,
+            signature: self.signature,
+            genericWhereClause: self.genericWhereClause,
+            body: self.body,
+            trailingTrivia: self.trailingTrivia
+        )
+    }
+
+    /// Returns a copy of the function declaration with the provided modifiers.
+    ///
+    /// - Parameter modifiers: The modifiers of the new function declaration.
+    /// - Returns: A copy of the function declaration with the provided
+    ///   modifiers.
+    public func withModifiers(
+        @DeclModifierListBuilder 
+        modifiersBuilder: @escaping () throws -> DeclModifierListSyntax
+    ) throws -> FunctionDeclSyntax {
+        try self.withModifiers(modifiersBuilder())
+    }
+}

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ModifiersTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ModifiersTests.swift
@@ -1,0 +1,61 @@
+//
+//  FunctionDeclSyntax_ModifiersTests.swift
+//  SwiftSyntaxSugarTests
+//
+//  Created by Gray Campbell on 7/17/24.
+//
+
+import SwiftSyntax
+import XCTest
+@testable import SwiftSyntaxSugar
+
+final class FunctionDeclSyntax_ModifiersTests: XCTestCase {
+
+    // MARK: Typealiases
+
+    typealias SUT = FunctionDeclSyntax
+
+    // MARK: With Modifiers Tests
+
+    func testWithModifiers() {
+        let sut = SUT(
+            modifiers: DeclModifierListSyntax {
+                DeclModifierSyntax(name: .keyword(.public))
+                DeclModifierSyntax(name: .keyword(.static))
+            },
+            name: "sut",
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        )
+        .withModifiers(DeclModifierListSyntax {
+            DeclModifierSyntax(name: .keyword(.private))
+            DeclModifierSyntax(name: .keyword(.mutating))
+        })
+
+        XCTAssertEqual(sut.modifiers.count, 2)
+        XCTAssertEqual(sut.modifiers.first?.name.tokenKind, .keyword(.private))
+        XCTAssertEqual(sut.modifiers.last?.name.tokenKind, .keyword(.mutating))
+    }
+
+    func testWithModifiersBuilder() throws {
+        let sut = try SUT(
+            modifiers: DeclModifierListSyntax {
+                DeclModifierSyntax(name: .keyword(.public))
+                DeclModifierSyntax(name: .keyword(.static))
+            },
+            name: "sut",
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        )
+        .withModifiers {
+            DeclModifierSyntax(name: .keyword(.private))
+            DeclModifierSyntax(name: .keyword(.mutating))
+        }
+
+        XCTAssertEqual(sut.modifiers.count, 2)
+        XCTAssertEqual(sut.modifiers.first?.name.tokenKind, .keyword(.private))
+        XCTAssertEqual(sut.modifiers.last?.name.tokenKind, .keyword(.mutating))
+    }
+}


### PR DESCRIPTION
## Summary
- Added `FunctionDeclSyntax.withModifiers`.
- Updated `FunctionDeclSyntax.withAccessLevel` to call `FunctionDeclSyntax.withModifiers`.
- Added unit tests.