### PR TITLE
Support upcoming Swift features

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/apple/swift-syntax.git",
-            from: "600.0.0"
+            from: "600.0.1"
         ),
     ],
     targets: [
@@ -29,11 +29,29 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-            ]
+            ],
+            swiftSettings: .default
         ),
         .testTarget(
             name: "SwiftSyntaxSugarTests",
-            dependencies: ["SwiftSyntaxSugar"]
+            dependencies: ["SwiftSyntaxSugar"],
+            swiftSettings: .default
         ),
     ]
 )
+
+// MARK: - Swift Settings
+
+extension SwiftSetting {
+    static let internalImportsByDefault: SwiftSetting = .enableUpcomingFeature("InternalImportsByDefault")
+    static let existentialAny: SwiftSetting = .enableUpcomingFeature("ExistentialAny")
+}
+
+extension Array where Element == SwiftSetting {
+
+    /// Default Swift settings to enable for targets.
+    static let `default`: [SwiftSetting] = [
+        .existentialAny,
+        .internalImportsByDefault
+    ]
+}

--- a/Sources/SwiftSyntaxSugar/AccessLevelSyntax/AccessLevelSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/AccessLevelSyntax/AccessLevelSyntax.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/3/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 /// An access level.
 public enum AccessLevelSyntax: String, CaseIterable, Hashable {

--- a/Sources/SwiftSyntaxSugar/AccessorBlockSyntax/AccessorBlockSyntax+Accessors.swift
+++ b/Sources/SwiftSyntaxSugar/AccessorBlockSyntax/AccessorBlockSyntax+Accessors.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/3/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension AccessorBlockSyntax {
 

--- a/Sources/SwiftSyntaxSugar/AccessorDeclSyntax/AccessorDeclSyntax+Effects.swift
+++ b/Sources/SwiftSyntaxSugar/AccessorDeclSyntax/AccessorDeclSyntax+Effects.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/3/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension AccessorDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/ClassDeclSyntax/ClassDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/ClassDeclSyntax/ClassDeclSyntax+AccessLevel.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension ClassDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/DeclModifierListSyntax/DeclModifierListSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/DeclModifierListSyntax/DeclModifierListSyntax+AccessLevel.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension DeclModifierListSyntax {
 

--- a/Sources/SwiftSyntaxSugar/DeclModifierSyntax/DeclModifierSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/DeclModifierSyntax/DeclModifierSyntax+AccessLevel.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension DeclModifierSyntax {
 

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+AccessLevel.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension FunctionDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Effects.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Effects.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension FunctionDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Parameters.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Parameters.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension FunctionDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+ToFunctionTypeSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+ToFunctionTypeSyntax.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension FunctionDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/FunctionParameterListSyntax/FunctionParameterListSyntax+ToTupleTypeSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionParameterListSyntax/FunctionParameterListSyntax+ToTupleTypeSyntax.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension FunctionParameterListSyntax {

--- a/Sources/SwiftSyntaxSugar/FunctionTypeSyntax/FunctionTypeSyntax+Escaping.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionTypeSyntax/FunctionTypeSyntax+Escaping.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension FunctionTypeSyntax {
 

--- a/Sources/SwiftSyntaxSugar/InheritedTypeListSyntax/InheritedTypeListSyntax+IdentifierTypes.swift
+++ b/Sources/SwiftSyntaxSugar/InheritedTypeListSyntax/InheritedTypeListSyntax+IdentifierTypes.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension InheritedTypeListSyntax {
 

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+AccessLevel.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension ProtocolDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Actor.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Actor.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension ProtocolDeclSyntax {
 
@@ -19,7 +19,7 @@ extension ProtocolDeclSyntax {
         let inheritedTypes = inheritanceClause.inheritedTypes
 
         return inheritedTypes.identifierTypes.contains { identifierType in
-            identifierType.name.trimmed.text == String(describing: Actor.self)
+            identifierType.name.trimmed.text == String(describing: (any Actor).self)
         }
     }
 }

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+AssociatedTypes.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+AssociatedTypes.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension ProtocolDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Functions.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Functions.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension ProtocolDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+GenericWhereClauses.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+GenericWhereClauses.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension ProtocolDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Type.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Type.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension ProtocolDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Variables.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Variables.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension ProtocolDeclSyntax {
 

--- a/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithCodeBlockSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithCodeBlockSyntax.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 7/17/24.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension SyntaxProtocol {

--- a/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithDeclModifierListSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithDeclModifierListSyntax.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 7/17/24.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension SyntaxProtocol {

--- a/Sources/SwiftSyntaxSugar/TypeSyntax/TypeSyntax+Describing.swift
+++ b/Sources/SwiftSyntaxSugar/TypeSyntax/TypeSyntax+Describing.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension TypeSyntax {
 

--- a/Sources/SwiftSyntaxSugar/VariableDeclSyntax/VariableDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/VariableDeclSyntax/VariableDeclSyntax+AccessLevel.swift
@@ -5,7 +5,7 @@
 //  Created by Gray Campbell on 11/4/23.
 //
 
-import SwiftSyntax
+public import SwiftSyntax
 
 extension VariableDeclSyntax {
 

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_ActorTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_ActorTests.swift
@@ -28,7 +28,7 @@ final class ProtocolDeclSyntax_ActorTests: XCTestCase {
             name: "SUT",
             inheritanceClause: InheritanceClauseSyntax {
                 InheritedTypeSyntax(type: TypeSyntax(describing: (any Hashable).self))
-                InheritedTypeSyntax(type: TypeSyntax(describing: Actor.self))
+                InheritedTypeSyntax(type: TypeSyntax(describing: (any Actor).self))
                 InheritedTypeSyntax(type: TypeSyntax(describing: (any Identifiable).self))
             }
         ) {}


### PR DESCRIPTION
Made the following modifications to SwiftSyntaxSugar:
- Updated Swift Syntax to 600.0.1 (from 600.0.0)
- Enabled import by default imports
  - Fixing the errors generated by this was just adding `public import`
- Enabled required existential any keyword
  - Fixing was just added the `any` keyword to one test.