### PR TITLE
Fix FunctionParameterListSyntax.toTupleTypeSyntax variadic parameters

### DIFF
--- a/Sources/SwiftSyntaxSugar/FunctionParameterListSyntax/FunctionParameterListSyntax+ToTupleTypeSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionParameterListSyntax/FunctionParameterListSyntax+ToTupleTypeSyntax.swift
@@ -50,7 +50,12 @@ extension FunctionParameterListSyntax {
             elements: TupleTypeElementListSyntax {
                 for parameter in self {
                     let attributedType = parameter.type.as(AttributedTypeSyntax.self)
-                    let type = attributedType?.baseType ?? parameter.type
+                    let parameterType = attributedType?.baseType ?? parameter.type
+                    let type: any TypeSyntaxProtocol = if parameter.isVariadic {
+                        ArrayTypeSyntax(element: parameterType)
+                    } else {
+                        parameterType
+                    }
 
                     if self.count == 1 {
                         TupleTypeElementSyntax(type: type)

--- a/Sources/SwiftSyntaxSugar/FunctionParameterSyntax/FunctionParameterSyntax+IsVariadic.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionParameterSyntax/FunctionParameterSyntax+IsVariadic.swift
@@ -1,0 +1,17 @@
+//
+//  FunctionParameterSyntax+IsVariadic.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 12/3/24.
+//
+
+public import SwiftSyntax
+
+extension FunctionParameterSyntax {
+
+    /// A Boolean value indicating whether the parameter is a variadic
+    /// parameter.
+    public var isVariadic: Bool {
+        self.ellipsis != nil
+    }
+}

--- a/Tests/SwiftSyntaxSugarTests/FunctionParameterListSyntax/FunctionParameterListSyntax_ToTupleTypeSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionParameterListSyntax/FunctionParameterListSyntax_ToTupleTypeSyntaxTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class FunctionParameterListSyntax_ToTupleTypeSyntaxTests: XCTestCase {
+struct FunctionParameterListSyntax_ToTupleTypeSyntaxTests {
 
     // MARK: Typealiases
 
@@ -17,17 +17,19 @@ final class FunctionParameterListSyntax_ToTupleTypeSyntaxTests: XCTestCase {
 
     // MARK: To TupleTypeSyntax Tests
 
-    func testToTupleTypeSyntaxWithOneParameters() throws {
+    @Test
+    func toTupleTypeSyntaxWithOneParameter() throws {
         let sut = SUT {
             FunctionParameterSyntax(firstName: "integer", type: .int)
         }
 
-        let tupleTypeSyntax = try XCTUnwrap(sut.toTupleTypeSyntax())
+        let tupleTypeSyntax = try #require(sut.toTupleTypeSyntax())
 
-        XCTAssertEqual(tupleTypeSyntax.description, "(Int)")
+        #expect(tupleTypeSyntax.description == "(Int)")
     }
 
-    func testToTupleTypeSyntaxWithMultipleParameters() throws {
+    @Test
+    func toTupleTypeSyntaxWithMultipleParameters() throws {
         let sut = SUT {
             FunctionParameterSyntax(firstName: "integer", type: .int)
             FunctionParameterSyntax(
@@ -42,15 +44,15 @@ final class FunctionParameterListSyntax_ToTupleTypeSyntaxTests: XCTestCase {
             )
         }
 
-        let tupleTypeSyntax = try XCTUnwrap(sut.toTupleTypeSyntax())
+        let tupleTypeSyntax = try #require(sut.toTupleTypeSyntax())
 
-        XCTAssertEqual(
-            tupleTypeSyntax.description,
-            "(integer:Int,closure:(String,Bool)->Void)"
+        #expect(
+            tupleTypeSyntax.description == "(integer:Int,closure:(String,Bool)->Void)"
         )
     }
 
-    func testToTupleTypeSyntaxWithAttributedParameters() throws {
+    @Test
+    func toTupleTypeSyntaxWithAttributedParameters() throws {
         // TODO: Remove AttributedTypeSyntax specifiers argument when deprecated init is removed.
         let sut = SUT {
             FunctionParameterSyntax(firstName: "integer", type: .int)
@@ -77,17 +79,32 @@ final class FunctionParameterListSyntax_ToTupleTypeSyntaxTests: XCTestCase {
             )
         }
 
-        let tupleTypeSyntax = try XCTUnwrap(sut.toTupleTypeSyntax())
+        let tupleTypeSyntax = try #require(sut.toTupleTypeSyntax())
 
-        XCTAssertEqual(
-            tupleTypeSyntax.description,
-            "(integer:Int,closure:(String,Bool)->Void)"
+        #expect(
+            tupleTypeSyntax.description == "(integer:Int,closure:(String,Bool)->Void)"
         )
     }
 
-    func testToFunctionTypeSyntaxWithoutParameters() {
+    @Test
+    func toTupleTypeSyntaxWithVariadicParameter() throws {
+        let sut = SUT {
+            FunctionParameterSyntax(
+                firstName: "integer",
+                type: .int,
+                ellipsis: .ellipsisToken()
+            )
+        }
+
+        let tupleTypeSyntax = try #require(sut.toTupleTypeSyntax())
+
+        #expect(tupleTypeSyntax.description == "([Int])")
+    }
+
+    @Test
+    func toTupleTypeSyntaxWithoutParameters() {
         let sut = SUT()
 
-        XCTAssertNil(sut.toTupleTypeSyntax())
+        #expect(sut.toTupleTypeSyntax() == nil)
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/FunctionParameterSyntax/FunctionParameterSyntax_IsVariadicTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionParameterSyntax/FunctionParameterSyntax_IsVariadicTests.swift
@@ -1,0 +1,42 @@
+//
+//  FunctionParameterSyntax_IsVariadicTests.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 12/9/24.
+//
+
+import SwiftSyntax
+import Testing
+@testable import SwiftSyntaxSugar
+
+struct FunctionParameterSyntax_IsVariadicTests {
+
+    // MARK: Typealiases
+
+    typealias SUT = FunctionParameterSyntax
+
+    // MARK: Is Variadic Tests
+
+    @Test
+    func isVariadicWhenEllipsisIsNil() {
+        let sut = SUT(
+            firstName: .identifier("parameter"),
+            colon: .colonToken(),
+            type: .int
+        )
+
+        #expect(!sut.isVariadic)
+    }
+
+    @Test
+    func isVariadicWhenEllipsisIsNotNil() {
+        let sut = SUT(
+            firstName: .identifier("parameter"),
+            colon: .colonToken(),
+            type: .int,
+            ellipsis: .ellipsisToken()
+        )
+
+        #expect(sut.isVariadic)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed #22.
- Updated some unit tests to Swift Testing.