### PR TITLE
Add accessLevel and withAccessLevel to InitializerDeclSyntax

### DIFF
--- a/Sources/SwiftSyntaxSugar/AccessLevelSyntax/AccessLevelSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/AccessLevelSyntax/AccessLevelSyntax.swift
@@ -8,7 +8,7 @@
 public import SwiftSyntax
 
 /// An access level.
-public enum AccessLevelSyntax: String, CaseIterable, Hashable {
+public enum AccessLevelSyntax: String, CaseIterable, Hashable, Sendable {
 
     // MARK: Cases
 

--- a/Sources/SwiftSyntaxSugar/InitializerDeclSyntax/InitializerDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/InitializerDeclSyntax/InitializerDeclSyntax+AccessLevel.swift
@@ -1,0 +1,37 @@
+//
+//  InitializerDeclSyntax+AccessLevel.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 12/9/24.
+//
+
+public import SwiftSyntax
+
+extension InitializerDeclSyntax {
+
+    /// The initializer declaration's access level.
+    public var accessLevel: AccessLevelSyntax {
+        self.modifiers.accessLevel
+    }
+
+    /// Returns a copy of the initializer declaration with the provided access
+    /// level.
+    ///
+    /// - Parameter accessLevel: The access level of the new initializer
+    ///   declaration.
+    /// - Returns: A copy of the initializer declaration with the provided
+    ///   access level.
+    public func withAccessLevel(
+        _ accessLevel: AccessLevelSyntax
+    ) throws -> InitializerDeclSyntax {
+        try self.with(\.modifiers) { modifiers in
+            if accessLevel != .internal {
+                accessLevel.modifier
+            }
+
+            for modifier in modifiers where !modifier.isAccessLevel {
+                modifier
+            }
+        }
+    }
+}

--- a/Tests/SwiftSyntaxSugarTests/InitializerDeclSyntax/InitializerDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/InitializerDeclSyntax/InitializerDeclSyntax_AccessLevelTests.swift
@@ -1,0 +1,82 @@
+//
+//  InitializerDeclSyntax_AccessLevelTests.swift
+//  SwiftSyntaxSugar
+//
+//  Created by Gray Campbell on 12/9/24.
+//
+
+import SwiftSyntax
+import Testing
+@testable import SwiftSyntaxSugar
+
+struct InitializerDeclSyntax_AccessLevelTests {
+
+    // MARK: Typealiases
+
+    typealias SUT = InitializerDeclSyntax
+
+    // MARK: Access Level Tests
+
+    @Test(arguments: AccessLevelSyntax.allCases)
+    func accessLevelWithExplicitAccessLevel(_ accessLevel: AccessLevelSyntax) {
+        let sut = SUT(
+            modifiers: DeclModifierListSyntax { accessLevel.modifier },
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        )
+
+        #expect(sut.accessLevel == accessLevel)
+    }
+
+    @Test
+    func accessLevelWithImplicitInternalAccessLevel() {
+        let sut = SUT(
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        )
+
+        #expect(sut.accessLevel == .internal)
+    }
+
+    // MARK: With Access Level Tests
+
+    @Test(arguments: AccessLevelSyntax.allCases, AccessLevelSyntax.allCases)
+    func withAccessLevelWithExplicitAccessLevels(
+        oldAccessLevel: AccessLevelSyntax,
+        newAccessLevel: AccessLevelSyntax
+    ) throws {
+        let sut = try SUT(
+            modifiers: DeclModifierListSyntax {
+                oldAccessLevel.modifier
+            },
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        )
+        .withAccessLevel(newAccessLevel)
+
+        let expectedModifierCount = newAccessLevel == .internal ? 0 : 1
+
+        #expect(sut.accessLevel == newAccessLevel)
+        #expect(sut.modifiers.count == expectedModifierCount)
+    }
+
+    @Test(arguments: AccessLevelSyntax.allCases)
+    func withAccessLevelWithImplicitInternalAccessLevel(
+        newAccessLevel: AccessLevelSyntax
+    ) throws {
+        let sut = try SUT(
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        )
+        .withAccessLevel(newAccessLevel)
+
+        let expectedModifierCount = newAccessLevel == .internal ? 0 : 1
+
+        #expect(sut.accessLevel == newAccessLevel)
+        #expect(sut.modifiers.count == expectedModifierCount)
+    }
+}


### PR DESCRIPTION
## Summary
- Added `accessLevel` computed property to `InitializerDeclSyntax`.
- Added `withAccessLevel` method to `InitializerDeclSyntax`.