### PR TITLE
Convert ClassDeclSyntax_AccessLevelTests to Swift Testing

### DIFF
--- a/Tests/SwiftSyntaxSugarTests/ClassDeclSyntax/ClassDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ClassDeclSyntax/ClassDeclSyntax_AccessLevelTests.swift
@@ -19,7 +19,7 @@ struct ClassDeclSyntax_AccessLevelTests {
 
     @Test(arguments: AccessLevelSyntax.allCases)
     func accessLevelWithExplicitAccessLevelModifier(
-        for accessLevel: AccessLevelSyntax
+        from accessLevel: AccessLevelSyntax
     ) {
         let modifiers = DeclModifierListSyntax {
             accessLevel.modifier


### PR DESCRIPTION
## Summary
- Converted `ClassDeclSyntax_AccessLevelTests` to Swift Testing.