### PR TITLE
Convert FunctionDeclSyntax unit tests to Swift Testing

### DIFF
--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_AccessLevelTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class FunctionDeclSyntax_AccessLevelTests: XCTestCase {
+struct FunctionDeclSyntax_AccessLevelTests {
 
     // MARK: Typealiases
 
@@ -17,21 +17,23 @@ final class FunctionDeclSyntax_AccessLevelTests: XCTestCase {
 
     // MARK: Access Level Tests
 
-    func testAccessLevelWithExplicitAccessLevels() {
-        for accessLevel in AccessLevelSyntax.allCases {
-            let sut = SUT(
-                modifiers: DeclModifierListSyntax { accessLevel.modifier },
-                name: "sut",
-                signature: FunctionSignatureSyntax(
-                    parameterClause: FunctionParameterClauseSyntax {}
-                )
+    @Test(arguments: AccessLevelSyntax.allCases)
+    func accessLevelWithExplicitAccessLevelModifier(
+        from accessLevel: AccessLevelSyntax
+    ) {
+        let sut = SUT(
+            modifiers: DeclModifierListSyntax { accessLevel.modifier },
+            name: "sut",
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
             )
+        )
 
-            XCTAssertEqual(sut.accessLevel, accessLevel)
-        }
+        #expect(sut.accessLevel == accessLevel)
     }
 
-    func testAccessLevelWithImplicitInternalAccessLevel() {
+    @Test
+    func accessLevelWithImplicitInternalAccessLevelModifier() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -39,53 +41,52 @@ final class FunctionDeclSyntax_AccessLevelTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(sut.accessLevel, .internal)
+        #expect(sut.accessLevel == .internal)
     }
 
     // MARK: With Access Level Tests
 
-    func testWithAccessLevelWithExplicitAccessLevels() throws {
-        for oldAccessLevel in AccessLevelSyntax.allCases {
-            for newAccessLevel in AccessLevelSyntax.allCases {
-                let sut = try SUT(
-                    modifiers: DeclModifierListSyntax {
-                        oldAccessLevel.modifier
-                        DeclModifierSyntax(name: .keyword(.static))
-                    },
-                    name: "sut",
-                    signature: FunctionSignatureSyntax(
-                        parameterClause: FunctionParameterClauseSyntax {}
-                    )
-                )
-                .withAccessLevel(newAccessLevel)
+    @Test(arguments: AccessLevelSyntax.allCases, AccessLevelSyntax.allCases)
+    func withAccessLevelWithExplicitAccessLevelModifier(
+        oldAccessLevel: AccessLevelSyntax,
+        newAccessLevel: AccessLevelSyntax
+    ) throws {
+        let sut = try SUT(
+            modifiers: DeclModifierListSyntax {
+                oldAccessLevel.modifier
+                DeclModifierSyntax(name: .keyword(.static))
+            },
+            name: "sut",
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        )
+        .withAccessLevel(newAccessLevel)
 
-                XCTAssertEqual(sut.accessLevel, newAccessLevel)
-                XCTAssertEqual(
-                    sut.modifiers.count,
-                    newAccessLevel == .internal ? 1 : 2
-                )
-            }
-        }
+        let expectedModifierCount = newAccessLevel == .internal ? 1 : 2
+
+        #expect(sut.accessLevel == newAccessLevel)
+        #expect(sut.modifiers.count == expectedModifierCount)
     }
 
-    func testWithAccessLevelWithImplicitInternalAccessLevel() throws {
-        for newAccessLevel in AccessLevelSyntax.allCases {
-            let sut = try SUT(
-                modifiers: DeclModifierListSyntax {
-                    DeclModifierSyntax(name: .keyword(.static))
-                },
-                name: "sut",
-                signature: FunctionSignatureSyntax(
-                    parameterClause: FunctionParameterClauseSyntax {}
-                )
+    @Test(arguments: AccessLevelSyntax.allCases)
+    func withAccessLevelWithImplicitInternalAccessLevelModifier(
+        newAccessLevel: AccessLevelSyntax
+    ) throws {
+        let sut = try SUT(
+            modifiers: DeclModifierListSyntax {
+                DeclModifierSyntax(name: .keyword(.static))
+            },
+            name: "sut",
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
             )
-            .withAccessLevel(newAccessLevel)
+        )
+        .withAccessLevel(newAccessLevel)
 
-            XCTAssertEqual(sut.accessLevel, newAccessLevel)
-            XCTAssertEqual(
-                sut.modifiers.count,
-                newAccessLevel == .internal ? 1 : 2
-            )
-        }
+        let expectedModifierCount = newAccessLevel == .internal ? 1 : 2
+
+        #expect(sut.accessLevel == newAccessLevel)
+        #expect(sut.modifiers.count == expectedModifierCount)
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_EffectsTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_EffectsTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class FunctionDeclSyntax_EffectsTests: XCTestCase {
+struct FunctionDeclSyntax_EffectsTests {
 
     // MARK: Typealiases
 
@@ -17,7 +17,8 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
 
     // MARK: Is Async Tests
 
-    func testIsAsyncWithNilAsyncSpecifier() {
+    @Test
+    func isAsyncWithNilAsyncSpecifier() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -26,10 +27,11 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(sut.isAsync)
+        #expect(!sut.isAsync)
     }
 
-    func testIsAsyncWithNonNilAsyncSpecifier() {
+    @Test
+    func isAsyncWithNonNilAsyncSpecifier() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -40,10 +42,11 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(sut.isAsync)
+        #expect(sut.isAsync)
     }
 
-    func testIsAsyncWithNilEffectSpecifiers() {
+    @Test
+    func isAsyncWithNilEffectSpecifiers() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -51,12 +54,13 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(sut.isAsync)
+        #expect(!sut.isAsync)
     }
 
     // MARK: Is Throwing Tests
 
-    func testIsThrowingWithNilThrowsSpecifier() {
+    @Test
+    func isThrowingWithNilThrowsSpecifier() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -65,10 +69,11 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(sut.isThrowing)
+        #expect(!sut.isThrowing)
     }
 
-    func testIsThrowingWithNonNilThrowsSpecifier() {
+    @Test
+    func isThrowingWithNonNilThrowsSpecifier() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -81,10 +86,11 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(sut.isThrowing)
+        #expect(sut.isThrowing)
     }
 
-    func testIsThrowingWithNilEffectSpecifiers() {
+    @Test
+    func isThrowingWithNilEffectSpecifiers() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -92,12 +98,13 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertFalse(sut.isThrowing)
+        #expect(!sut.isThrowing)
     }
 
     // MARK: Invocation Keyword Tokens Tests
 
-    func testInvocationKeywordTokensWithNonNilAsyncSpecifier() throws {
+    @Test
+    func invocationKeywordTokensWithNonNilAsyncSpecifier() throws {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -108,14 +115,15 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        let invocationKeywordTokens = try XCTUnwrap(sut.invocationKeywordTokens)
-        let awaitKeywordToken = try XCTUnwrap(invocationKeywordTokens.first)
+        let invocationKeywordTokens = try #require(sut.invocationKeywordTokens)
+        let awaitKeywordToken = try #require(invocationKeywordTokens.first)
 
-        XCTAssertEqual(invocationKeywordTokens.count, 1)
-        XCTAssertEqual(awaitKeywordToken.text, "await")
+        #expect(invocationKeywordTokens.count == 1)
+        #expect(awaitKeywordToken.tokenKind == .keyword(.await))
     }
 
-    func testInvocationKeywordTokensWithNonNilThrowsSpecifier() throws {
+    @Test
+    func invocationKeywordTokensWithNonNilThrowsSpecifier() throws {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -128,14 +136,15 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        let invocationKeywordTokens = try XCTUnwrap(sut.invocationKeywordTokens)
-        let tryKeywordToken = try XCTUnwrap(invocationKeywordTokens.first)
+        let invocationKeywordTokens = try #require(sut.invocationKeywordTokens)
+        let tryKeywordToken = try #require(invocationKeywordTokens.first)
 
-        XCTAssertEqual(invocationKeywordTokens.count, 1)
-        XCTAssertEqual(tryKeywordToken.text, "try")
+        #expect(invocationKeywordTokens.count == 1)
+        #expect(tryKeywordToken.tokenKind == .keyword(.try))
     }
 
-    func testInvocationKeywordTokensWithNilAsyncAndThrowsSpecifiers() {
+    @Test
+    func invocationKeywordTokensWithNilAsyncAndThrowsSpecifiers() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -144,10 +153,11 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(sut.invocationKeywordTokens.isEmpty)
+        #expect(sut.invocationKeywordTokens.isEmpty)
     }
 
-    func testInvocationKeywordTokensWithNonNilAsyncAndThrowsSpecifiers() throws {
+    @Test
+    func invocationKeywordTokensWithNonNilAsyncAndThrowsSpecifiers() throws {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -161,16 +171,17 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        let invocationKeywordTokens = try XCTUnwrap(sut.invocationKeywordTokens)
-        let tryKeywordToken = try XCTUnwrap(invocationKeywordTokens.first)
-        let awaitKeywordToken = try XCTUnwrap(invocationKeywordTokens.last)
+        let invocationKeywordTokens = try #require(sut.invocationKeywordTokens)
+        let tryKeywordToken = try #require(invocationKeywordTokens.first)
+        let awaitKeywordToken = try #require(invocationKeywordTokens.last)
 
-        XCTAssertEqual(invocationKeywordTokens.count, 2)
-        XCTAssertEqual(tryKeywordToken.text, "try")
-        XCTAssertEqual(awaitKeywordToken.text, "await")
+        #expect(invocationKeywordTokens.count == 2)
+        #expect(tryKeywordToken.tokenKind == .keyword(.try))
+        #expect(awaitKeywordToken.tokenKind == .keyword(.await))
     }
 
-    func testInvocationKeywordTokensWithNilEffectSpecifiers() {
+    @Test
+    func invocationKeywordTokensWithNilEffectSpecifiers() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -178,6 +189,6 @@ final class FunctionDeclSyntax_EffectsTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(sut.invocationKeywordTokens.isEmpty)
+        #expect(sut.invocationKeywordTokens.isEmpty)
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ParametersTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ParametersTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class FunctionDeclSyntax_ParametersTests: XCTestCase {
+struct FunctionDeclSyntax_ParametersTests {
 
     // MARK: Typealiases
 
@@ -17,7 +17,8 @@ final class FunctionDeclSyntax_ParametersTests: XCTestCase {
 
     // MARK: Parameter Variable Names Tests
 
-    func testParameterVariableNamesWithEmptyParameters() throws {
+    @Test
+    func parameterVariableNamesWithEmptyParameters() throws {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -25,10 +26,11 @@ final class FunctionDeclSyntax_ParametersTests: XCTestCase {
             )
         )
 
-        XCTAssertTrue(sut.parameterVariableNames.isEmpty)
+        #expect(sut.parameterVariableNames.isEmpty)
     }
 
-    func testParameterVariableNamesWithNonEmptyParameters() throws {
+    @Test
+    func parameterVariableNamesWithNonEmptyParameters() throws {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -46,15 +48,15 @@ final class FunctionDeclSyntax_ParametersTests: XCTestCase {
             )
         )
 
-        let parameterVariableNames = try XCTUnwrap(sut.parameterVariableNames)
-        let firstParameterVariableName = try XCTUnwrap(
+        let parameterVariableNames = try #require(sut.parameterVariableNames)
+        let firstParameterVariableName = try #require(
             parameterVariableNames.first
         )
-        let lastParameterVariableName = try XCTUnwrap(
+        let lastParameterVariableName = try #require(
             parameterVariableNames.last
         )
 
-        XCTAssertEqual(firstParameterVariableName.text, "increment")
-        XCTAssertEqual(lastParameterVariableName.text, "limit")
+        #expect(firstParameterVariableName.tokenKind == .identifier("increment"))
+        #expect(lastParameterVariableName.tokenKind == .identifier("limit"))
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ToFunctionTypeSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ToFunctionTypeSyntaxTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
+struct FunctionDeclSyntax_ToFunctionTypeSyntaxTests {
 
     // MARK: Typealiases
 
@@ -17,7 +17,8 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
 
     // MARK: To FunctionTypeSyntax Tests
 
-    func testToFunctionTypeSyntaxWithParameters() {
+    @Test
+    func toFunctionTypeSyntaxWithParameters() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -37,13 +38,14 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            sut.toFunctionTypeSyntax().description,
-            "(Int,(String,Bool)->Void)->Void"
-        )
+        let functionTypeSyntax = sut.toFunctionTypeSyntax()
+        let expectedDescription = "(Int,(String,Bool)->Void)->Void"
+
+        #expect(functionTypeSyntax.description == expectedDescription)
     }
 
-    func testToFunctionTypeSyntaxWithAttributedParameters() {
+    @Test
+    func toFunctionTypeSyntaxWithAttributedParameters() {
         // TODO: Remove AttributedTypeSyntax specifiers argument when deprecated init is removed.
         let sut = SUT(
             name: "sut",
@@ -75,13 +77,14 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            sut.toFunctionTypeSyntax().description,
-            "(Int,(String,Bool)->Void)->Void"
-        )
+        let functionTypeSyntax = sut.toFunctionTypeSyntax()
+        let expectedDescription = "(Int,(String,Bool)->Void)->Void"
+
+        #expect(functionTypeSyntax.description == expectedDescription)
     }
 
-    func testToFunctionTypeSyntaxWithoutParameters() {
+    @Test
+    func toFunctionTypeSyntaxWithoutParameters() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -89,13 +92,14 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            sut.toFunctionTypeSyntax().description,
-            "()->Void"
-        )
+        let functionTypeSyntax = sut.toFunctionTypeSyntax()
+        let expectedDescription = "()->Void"
+
+        #expect(functionTypeSyntax.description == expectedDescription)
     }
 
-    func testToFunctionTypeSyntaxWithAsyncSpecifier() {
+    @Test
+    func toFunctionTypeSyntaxWithAsyncSpecifier() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -106,13 +110,14 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            sut.toFunctionTypeSyntax().description,
-            "()async->Void"
-        )
+        let functionTypeSyntax = sut.toFunctionTypeSyntax()
+        let expectedDescription = "()async->Void"
+
+        #expect(functionTypeSyntax.description == expectedDescription)
     }
 
-    func testToFunctionTypeSyntaxWithThrowsSpecifier() {
+    @Test
+    func toFunctionTypeSyntaxWithThrowsSpecifier() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -125,13 +130,14 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            sut.toFunctionTypeSyntax().description,
-            "()throws->Void"
-        )
+        let functionTypeSyntax = sut.toFunctionTypeSyntax()
+        let expectedDescription = "()throws->Void"
+
+        #expect(functionTypeSyntax.description == expectedDescription)
     }
 
-    func testToFunctionTypeSyntaxWithAsyncAndThrowsSpecifiers() {
+    @Test
+    func toFunctionTypeSyntaxWithAsyncAndThrowsSpecifiers() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -145,13 +151,14 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            sut.toFunctionTypeSyntax().description,
-            "()asyncthrows->Void"
-        )
+        let functionTypeSyntax = sut.toFunctionTypeSyntax()
+        let expectedDescription = "()asyncthrows->Void"
+
+        #expect(functionTypeSyntax.description == expectedDescription)
     }
 
-    func testToFunctionTypeSyntaxWithReturnValue() {
+    @Test
+    func toFunctionTypeSyntaxWithReturnValue() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -160,13 +167,14 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            sut.toFunctionTypeSyntax().description,
-            "()->Bool"
-        )
+        let functionTypeSyntax = sut.toFunctionTypeSyntax()
+        let expectedDescription = "()->Bool"
+
+        #expect(functionTypeSyntax.description == expectedDescription)
     }
 
-    func testToFunctionTypeSyntaxWithoutReturnValue() {
+    @Test
+    func toFunctionTypeSyntaxWithoutReturnValue() {
         let sut = SUT(
             name: "sut",
             signature: FunctionSignatureSyntax(
@@ -174,9 +182,9 @@ final class FunctionDeclSyntax_ToFunctionTypeSyntaxTests: XCTestCase {
             )
         )
 
-        XCTAssertEqual(
-            sut.toFunctionTypeSyntax().description,
-            "()->Void"
-        )
+        let functionTypeSyntax = sut.toFunctionTypeSyntax()
+        let expectedDescription = "()->Void"
+
+        #expect(functionTypeSyntax.description == expectedDescription)
     }
 }


### PR DESCRIPTION
## Summary
- Converted `FunctionDeclSyntax` unit tests to Swift Testing.