### PR TITLE
Convert FunctionTypeSyntax_EscapingTests to Swift Testing

### DIFF
--- a/Tests/SwiftSyntaxSugarTests/FunctionTypeSyntax/FunctionTypeSyntax_EscapingTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionTypeSyntax/FunctionTypeSyntax_EscapingTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class FunctionTypeSyntax_EscapingTests: XCTestCase {
+struct FunctionTypeSyntax_EscapingTests {
 
     // MARK: Typealiases
 
@@ -17,15 +17,16 @@ final class FunctionTypeSyntax_EscapingTests: XCTestCase {
 
     // MARK: Escaping Tests
 
-    func testEscaping() {
+    @Test
+    func escaping() {
         let sut = SUT(
             parameters: TupleTypeElementListSyntax(),
             returnClause: ReturnClauseSyntax(type: .bool)
         )
 
-        XCTAssertEqual(
-            sut.escaping().description,
-            "@escaping()->Bool"
-        )
+        let sutEscaping = sut.escaping()
+        let expectedDescription = "@escaping()->Bool"
+
+        #expect(sutEscaping.description == expectedDescription)
     }
 }


### PR DESCRIPTION
## Summary
- Converted `FunctionTypeSyntax_EscapingTests` to Swift Testing.