### PR TITLE
Convert ProtocolDeclSyntax tests to Swift Testing

### DIFF
--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+GenericWhereClauses.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+GenericWhereClauses.swift
@@ -19,7 +19,9 @@ extension ProtocolDeclSyntax {
         }
 
         for associatedTypeDeclaration in self.associatedTypeDeclarations {
-            guard let genericWhereClause = associatedTypeDeclaration.genericWhereClause else {
+            guard
+                let genericWhereClause = associatedTypeDeclaration.genericWhereClause
+            else {
                 continue
             }
 

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Type.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Type.swift
@@ -11,6 +11,8 @@ extension ProtocolDeclSyntax {
 
     /// The protocol as a type.
     public var type: TypeSyntax {
-        TypeSyntax(stringLiteral: self.name.text)
+        TypeSyntax(
+            IdentifierTypeSyntax(name: self.name)
+        )
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_AccessLevelTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class ProtocolDeclSyntax_AccessLevelTests: XCTestCase {
+struct ProtocolDeclSyntax_AccessLevelTests {
 
     // MARK: Typealiases
 
@@ -17,21 +17,23 @@ final class ProtocolDeclSyntax_AccessLevelTests: XCTestCase {
 
     // MARK: Access Level Tests
 
-    func testAccessLevelWithExplicitAccessLevels() {
-        for accessLevel in AccessLevelSyntax.allCases {
-            let sut = SUT(
-                modifiers: DeclModifierListSyntax {
-                    accessLevel.modifier
-                    DeclModifierSyntax(name: .keyword(.static))
-                },
-                name: "SUT"
-            ) {}
+    @Test(arguments: AccessLevelSyntax.allCases)
+    func accessLevelWithExplicitAccessLevelModifier(
+        from accessLevel: AccessLevelSyntax
+    ) {
+        let sut = SUT(
+            modifiers: DeclModifierListSyntax {
+                accessLevel.modifier
+                DeclModifierSyntax(name: .keyword(.static))
+            },
+            name: "SUT"
+        ) {}
 
-            XCTAssertEqual(sut.accessLevel, accessLevel)
-        }
+        #expect(sut.accessLevel == accessLevel)
     }
 
-    func testAccessLevelWithImplicitInternalAccessLevel() {
+    @Test
+    func accessLevelWithImplicitInternalAccessLevelModifier() {
         let sut = SUT(
             modifiers: DeclModifierListSyntax {
                 DeclModifierSyntax(name: .keyword(.static))
@@ -39,33 +41,35 @@ final class ProtocolDeclSyntax_AccessLevelTests: XCTestCase {
             name: "SUT"
         ) {}
 
-        XCTAssertEqual(sut.accessLevel, .internal)
+        #expect(sut.accessLevel == .internal)
     }
 
     // MARK: Minimum Conforming Access Level Tests
 
-    func testMinimumConformingAccessLevelWithExplicitAccessLevels() {
-        for accessLevel in AccessLevelSyntax.allCases {
-            let sut = SUT(
-                modifiers: DeclModifierListSyntax {
-                    accessLevel.modifier
-                    DeclModifierSyntax(name: .keyword(.static))
-                },
-                name: "SUT"
-            ) {}
-            let expectedMinimumConformingAccessLevel: AccessLevelSyntax = switch accessLevel {
-            case .fileprivate, .private: .fileprivate
-            case .internal, .open, .package, .public: accessLevel
-            }
+    @Test(arguments: AccessLevelSyntax.allCases)
+    func minimumConformingAccessLevelWithExplicitAccessLevelModifier(
+        from accessLevel: AccessLevelSyntax
+    ) {
+        let sut = SUT(
+            modifiers: DeclModifierListSyntax {
+                accessLevel.modifier
+                DeclModifierSyntax(name: .keyword(.static))
+            },
+            name: "SUT"
+        ) {}
 
-            XCTAssertEqual(
-                sut.minimumConformingAccessLevel,
-                expectedMinimumConformingAccessLevel
-            )
+        let expectedMinimumConformingAccessLevel: AccessLevelSyntax = switch accessLevel {
+        case .fileprivate, .private: .fileprivate
+        case .internal, .open, .package, .public: accessLevel
         }
+
+        #expect(
+            sut.minimumConformingAccessLevel == expectedMinimumConformingAccessLevel
+        )
     }
 
-    func testMinimumConformingAccessLevelWithImplicitInternalAccessLevel() {
+    @Test
+    func minimumConformingAccessLevelWithImplicitInternalAccessLevelModifier() {
         let sut = SUT(
             modifiers: DeclModifierListSyntax {
                 DeclModifierSyntax(name: .keyword(.static))
@@ -73,6 +77,6 @@ final class ProtocolDeclSyntax_AccessLevelTests: XCTestCase {
             name: "SUT"
         ) {}
 
-        XCTAssertEqual(sut.minimumConformingAccessLevel, .internal)
+        #expect(sut.minimumConformingAccessLevel == .internal)
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_ActorTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_ActorTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class ProtocolDeclSyntax_ActorTests: XCTestCase {
+struct ProtocolDeclSyntax_ActorTests {
 
     // MARK: Typealiases
 
@@ -17,13 +17,15 @@ final class ProtocolDeclSyntax_ActorTests: XCTestCase {
 
     // MARK: Is Actor Constrained Tests
 
-    func testIsActorConstrainedWithNilInheritanceClause() {
+    @Test
+    func isActorConstrainedWithNilInheritanceClause() {
         let sut = SUT(name: "SUT") {}
 
-        XCTAssertFalse(sut.isActorConstrained)
+        #expect(!sut.isActorConstrained)
     }
 
-    func testIsActorConstrainedWithNonNilInheritanceClauseWithActorConformance() {
+    @Test
+    func isActorConstrainedWithNonNilInheritanceClauseWithActorConformance() {
         let sut = SUT(
             name: "SUT",
             inheritanceClause: InheritanceClauseSyntax {
@@ -33,10 +35,11 @@ final class ProtocolDeclSyntax_ActorTests: XCTestCase {
             }
         ) {}
 
-        XCTAssertTrue(sut.isActorConstrained)
+        #expect(sut.isActorConstrained)
     }
 
-    func testIsActorConstrainedWithNonNilInheritanceClauseWithoutActorConformance() {
+    @Test
+    func isActorConstrainedWithNonNilInheritanceClauseWithoutActorConformance() {
         let sut = SUT(
             name: "SUT",
             inheritanceClause: InheritanceClauseSyntax {
@@ -45,6 +48,6 @@ final class ProtocolDeclSyntax_ActorTests: XCTestCase {
             }
         ) {}
 
-        XCTAssertFalse(sut.isActorConstrained)
+        #expect(!sut.isActorConstrained)
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_AssociatedTypesTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_AssociatedTypesTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class ProtocolDeclSyntax_AssociatedTypesTests: XCTestCase {
+struct ProtocolDeclSyntax_AssociatedTypesTests {
 
     // MARK: Typealiases
 
@@ -17,13 +17,15 @@ final class ProtocolDeclSyntax_AssociatedTypesTests: XCTestCase {
 
     // MARK: Associated Type Declarations Tests
 
-    func testAssociatedTypeDeclarationsWithEmptyMemberBlock() {
+    @Test
+    func associatedTypeDeclarationsWithEmptyMemberBlock() {
         let sut = SUT(name: "SUT") {}
 
-        XCTAssertTrue(sut.associatedTypeDeclarations.isEmpty)
+        #expect(sut.associatedTypeDeclarations.isEmpty)
     }
 
-    func testAssociatedTypeDeclarationsWithNonEmptyMemberBlockWithAssociatedTypes() {
+    @Test
+    func associatedTypeDeclarationsWithNonEmptyMemberBlockWithAssociatedTypes() {
         let sut = SUT(name: "SUT") {
             VariableDeclSyntax(.var, name: "a")
             AssociatedTypeDeclSyntax(name: "A")
@@ -31,15 +33,16 @@ final class ProtocolDeclSyntax_AssociatedTypesTests: XCTestCase {
             AssociatedTypeDeclSyntax(name: "B")
         }
 
-        XCTAssertEqual(sut.associatedTypeDeclarations.count, 2)
+        #expect(sut.associatedTypeDeclarations.count == 2)
     }
 
-    func testAssociatedTypeDeclarationsWithNonEmptyMemberBlockWithoutAssociatedTypes() {
+    @Test
+    func associatedTypeDeclarationsWithNonEmptyMemberBlockWithoutAssociatedTypes() {
         let sut = SUT(name: "SUT") {
             VariableDeclSyntax(.var, name: "a")
             VariableDeclSyntax(.var, name: "b")
         }
 
-        XCTAssertTrue(sut.associatedTypeDeclarations.isEmpty)
+        #expect(sut.associatedTypeDeclarations.isEmpty)
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_FunctionsTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_FunctionsTests.swift
@@ -6,12 +6,58 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class ProtocolDeclSyntax_FunctionsTests: XCTestCase {
+struct ProtocolDeclSyntax_FunctionsTests {
 
     // MARK: Typealiases
 
     typealias SUT = ProtocolDeclSyntax
+
+    // MARK: Function Declarations Tests
+
+    @Test
+    func functionDeclarations() {
+        let sut = SUT(name: "SUT") {
+            self.initializerDeclaration()
+            self.propertyDeclaration(name: "property1")
+            self.initializerDeclaration()
+            self.methodDeclaration(name: "method1")
+            self.initializerDeclaration()
+            self.propertyDeclaration(name: "property2")
+            self.initializerDeclaration()
+            self.methodDeclaration(name: "method2")
+            self.initializerDeclaration()
+            self.propertyDeclaration(name: "property3")
+            self.initializerDeclaration()
+        }
+
+        #expect(sut.functionDeclarations.count == 2)
+    }
+}
+
+// MARK: - Helpers
+
+extension ProtocolDeclSyntax_FunctionsTests {
+    private func initializerDeclaration() -> InitializerDeclSyntax {
+        InitializerDeclSyntax(
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        ) {}
+    }
+
+    private func methodDeclaration(name: String) -> FunctionDeclSyntax {
+        FunctionDeclSyntax(
+            name: .identifier(name),
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        ) {}
+    }
+
+    private func propertyDeclaration(name: PatternSyntax) -> VariableDeclSyntax {
+        VariableDeclSyntax(.var, name: name)
+    }
 }

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_GenericWhereClausesTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_GenericWhereClausesTests.swift
@@ -6,12 +6,34 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class ProtocolDeclSyntax_GenericWhereClausesTests: XCTestCase {
+struct ProtocolDeclSyntax_GenericWhereClausesTests {
 
     // MARK: Typealiases
 
     typealias SUT = ProtocolDeclSyntax
+
+    // MARK: Generic Where Clauses Tests
+
+    @Test
+    func genericWhereClauses() throws {
+        let sut = SUT(
+            name: "SUT",
+            genericWhereClause: GenericWhereClauseSyntax {}
+        ) {
+            AssociatedTypeDeclSyntax(
+                name: "A",
+                genericWhereClause: GenericWhereClauseSyntax {}
+            )
+            AssociatedTypeDeclSyntax(name: "B")
+            AssociatedTypeDeclSyntax(
+                name: "C",
+                genericWhereClause: GenericWhereClauseSyntax {}
+            )
+        }
+
+        #expect(sut.genericWhereClauses.count == 3)
+    }
 }

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_InitializersTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_InitializersTests.swift
@@ -19,7 +19,7 @@ struct ProtocolDeclSyntax_InitializersTests {
 
     @Test
     func initializerDeclarations() {
-        let sut = SUT(name: .identifier("Initializers")) {
+        let sut = SUT(name: "SUT") {
             self.initializerDeclaration()
             self.propertyDeclaration(name: "property1")
             self.initializerDeclaration()

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_TypeTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_TypeTests.swift
@@ -6,12 +6,26 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class ProtocolDeclSyntax_TypeTests: XCTestCase {
+struct ProtocolDeclSyntax_TypeTests {
 
     // MARK: Typealiases
 
     typealias SUT = ProtocolDeclSyntax
+
+    // MARK: Type Tests
+
+    @Test
+    func type() throws {
+        let sut = SUT(name: "SUT") {}
+
+        let type = sut.type
+        let identifierType = try #require(type.as(IdentifierTypeSyntax.self))
+        let identifierTypeTokenKind = identifierType.name.tokenKind
+        let expectedIdentifierTypeTokenKind: TokenKind = .identifier("SUT")
+
+        #expect(identifierTypeTokenKind == expectedIdentifierTypeTokenKind)
+    }
 }

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_VariablesTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_VariablesTests.swift
@@ -6,12 +6,58 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class ProtocolDeclSyntax_VariablesTests: XCTestCase {
+struct ProtocolDeclSyntax_VariablesTests {
 
     // MARK: Typealiases
 
     typealias SUT = ProtocolDeclSyntax
+
+    // MARK: Variable Declarations Tests
+
+    @Test
+    func variableDeclarations() {
+        let sut = SUT(name: "SUT") {
+            self.initializerDeclaration()
+            self.propertyDeclaration(name: "property1")
+            self.initializerDeclaration()
+            self.methodDeclaration(name: "method1")
+            self.initializerDeclaration()
+            self.propertyDeclaration(name: "property2")
+            self.initializerDeclaration()
+            self.methodDeclaration(name: "method2")
+            self.initializerDeclaration()
+            self.propertyDeclaration(name: "property3")
+            self.initializerDeclaration()
+        }
+
+        #expect(sut.variableDeclarations.count == 3)
+    }
+}
+
+// MARK: - Helpers
+
+extension ProtocolDeclSyntax_VariablesTests {
+    private func initializerDeclaration() -> InitializerDeclSyntax {
+        InitializerDeclSyntax(
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        ) {}
+    }
+
+    private func methodDeclaration(name: String) -> FunctionDeclSyntax {
+        FunctionDeclSyntax(
+            name: .identifier(name),
+            signature: FunctionSignatureSyntax(
+                parameterClause: FunctionParameterClauseSyntax {}
+            )
+        ) {}
+    }
+
+    private func propertyDeclaration(name: PatternSyntax) -> VariableDeclSyntax {
+        VariableDeclSyntax(.var, name: name)
+    }
 }


### PR DESCRIPTION
## Summary
- Converted `ProtocolDeclSyntax` tests to Swift Testing.
- Added tests to `ProtocolDeclSyntax_FunctionsTests`.
- Added tests to `ProtocolDeclSyntax_GenericWhereClausesTests`.
- Added tests to `ProtocolDeclSyntax_TypeTests`.
- Added tests to `ProtocolDeclSyntax_VariablesTests`.