### PR TITLE
Convert SyntaxProtocol tests to Swift Testing

### DIFF
--- a/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithCodeBlockSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithCodeBlockSyntaxTests.swift
@@ -6,19 +6,16 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class SyntaxProtocol_WithCodeBlockSyntaxTests: XCTestCase {
+struct SyntaxProtocol_WithCodeBlockSyntaxTests {
 
-    // MARK: Typealiases
+    // MARK: With Optional CodeBlockSyntax Tests
 
-    typealias SUT = FunctionDeclSyntax
-
-    // MARK: With CodeBlockSyntax Tests
-
-    func testWithCodeBlockSyntax() throws {
-        let sut = try SUT(
+    @Test
+    func withOptionalCodeBlockSyntax() throws {
+        let sut = try FunctionDeclSyntax(
             name: "sut",
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax {}
@@ -26,11 +23,12 @@ final class SyntaxProtocol_WithCodeBlockSyntaxTests: XCTestCase {
         )
         .with(\.body) {}
 
-        XCTAssertNotNil(sut.body)
+        #expect(sut.body != nil)
     }
 
-    func testWithCodeBlockSyntaxWithClosureParameter() throws {
-        let sut = try SUT(
+    @Test
+    func withOptionalCodeBlockSyntaxWithClosureParameter() throws {
+        let sut = try FunctionDeclSyntax(
             name: "sut",
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax {}
@@ -38,6 +36,6 @@ final class SyntaxProtocol_WithCodeBlockSyntaxTests: XCTestCase {
         )
         .with(\.body) { _ in }
 
-        XCTAssertNotNil(sut.body)
+        #expect(sut.body != nil)
     }
 }

--- a/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithDeclModifierListSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithDeclModifierListSyntaxTests.swift
@@ -6,19 +6,16 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class SyntaxProtocol_WithDeclModifierListSyntaxTests: XCTestCase {
+struct SyntaxProtocol_WithDeclModifierListSyntaxTests {
 
-    // MARK: Typealiases
+    // MARK: With Optional DeclModifierListSyntax Tests
 
-    typealias SUT = FunctionDeclSyntax
-
-    // MARK: With DeclModifierListSyntax Tests
-
-    func testWithDeclModifierListSyntax() throws {
-        let sut = try SUT(
+    @Test
+    func withOptionalDeclModifierListSyntax() throws {
+        let sut = try FunctionDeclSyntax(
             name: "sut",
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax {}
@@ -29,16 +26,17 @@ final class SyntaxProtocol_WithDeclModifierListSyntaxTests: XCTestCase {
             DeclModifierSyntax(name: .keyword(.static))
         }
 
-        let modifier1 = try XCTUnwrap(sut.modifiers.first)
-        let modifier2 = try XCTUnwrap(sut.modifiers.last)
+        let modifier1 = try #require(sut.modifiers.first)
+        let modifier2 = try #require(sut.modifiers.last)
 
-        XCTAssertEqual(sut.modifiers.count, 2)
-        XCTAssertEqual(modifier1.name.tokenKind, .keyword(.private))
-        XCTAssertEqual(modifier2.name.tokenKind, .keyword(.static))
+        #expect(sut.modifiers.count == 2)
+        #expect(modifier1.name.tokenKind == .keyword(.private))
+        #expect(modifier2.name.tokenKind == .keyword(.static))
     }
 
-    func testWithDeclModifierListSyntaxWithClosureParameter() throws {
-        let sut = try SUT(
+    @Test
+    func withOptionalDeclModifierListSyntaxWithClosureParameter() throws {
+        let sut = try FunctionDeclSyntax(
             name: "sut",
             signature: FunctionSignatureSyntax(
                 parameterClause: FunctionParameterClauseSyntax {}
@@ -49,11 +47,11 @@ final class SyntaxProtocol_WithDeclModifierListSyntaxTests: XCTestCase {
             DeclModifierSyntax(name: .keyword(.static))
         }
 
-        let modifier1 = try XCTUnwrap(sut.modifiers.first)
-        let modifier2 = try XCTUnwrap(sut.modifiers.last)
+        let modifier1 = try #require(sut.modifiers.first)
+        let modifier2 = try #require(sut.modifiers.last)
 
-        XCTAssertEqual(sut.modifiers.count, 2)
-        XCTAssertEqual(modifier1.name.tokenKind, .keyword(.private))
-        XCTAssertEqual(modifier2.name.tokenKind, .keyword(.static))
+        #expect(sut.modifiers.count == 2)
+        #expect(modifier1.name.tokenKind == .keyword(.private))
+        #expect(modifier2.name.tokenKind == .keyword(.static))
     }
 }


### PR DESCRIPTION
## Summary
- Converted `SyntaxProtocol_WithCodeBlockSyntaxTests` to Swift Testing.
- Converted `SyntaxProtocol_WithDeclModifierListSyntaxTests` to Swift Testing.