### PR TITLE
Convert TypeSyntax_DescribingTests to Swift Testing

### DIFF
--- a/Sources/SwiftSyntaxSugar/TypeSyntax/TypeSyntax+Describing.swift
+++ b/Sources/SwiftSyntaxSugar/TypeSyntax/TypeSyntax+Describing.swift
@@ -22,7 +22,11 @@ extension TypeSyntax {
     /// TypeSyntax(describing: Int.self)
     /// ```
     public init(describing subject: some Any) {
-        self.init(stringLiteral: String(describing: subject))
+        let identifier = String(describing: subject)
+
+        self.init(
+            IdentifierTypeSyntax(name: .identifier(identifier))
+        )
     }
 }
 

--- a/Tests/SwiftSyntaxSugarTests/TypeSyntax/TypeSyntax_DescribingTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/TypeSyntax/TypeSyntax_DescribingTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class TypeSyntax_DescribingTests: XCTestCase {
+struct TypeSyntax_DescribingTests {
 
     // MARK: Typealiases
 
@@ -17,18 +17,30 @@ final class TypeSyntax_DescribingTests: XCTestCase {
 
     // MARK: Initializer Tests
 
-    func testInitDescribingSubject() {
+    @Test
+    func initDescribingSubject() throws {
         let sut = SUT(describing: Int.self)
 
-        XCTAssertEqual(sut.description, "Int")
+        let identifierType = try #require(sut.as(IdentifierTypeSyntax.self))
+        let identifierTypeTokenKind = identifierType.name.tokenKind
+
+        #expect(identifierTypeTokenKind == .identifier("Int"))
     }
 
     // MARK: Static Property Tests
 
-    func testStaticProperties() {
-        XCTAssertEqual(SUT.bool.description, "Bool")
-        XCTAssertEqual(SUT.int.description, "Int")
-        XCTAssertEqual(SUT.string.description, "String")
-        XCTAssertEqual(SUT.void.description, "Void")
+    @Test(
+        arguments: [
+            (SUT.bool, "Bool"),
+            (SUT.int, "Int"),
+            (SUT.string, "String"),
+            (SUT.void, "Void"),
+        ]
+    )
+    func staticProperty(sut: SUT, expectedIdentifier: String) throws {
+        let identifierType = try #require(sut.as(IdentifierTypeSyntax.self))
+        let identifierTypeTokenKind = identifierType.name.tokenKind
+
+        #expect(identifierTypeTokenKind == .identifier(expectedIdentifier))
     }
 }


### PR DESCRIPTION
## Summary
- Refactored `TypeSyntax.init(describing:)`.
- Converted `TypeSyntax_DescribingTests` to Swift Testing.