### PR TITLE
Convert VariableDeclSyntax_AccessLevelTests to Swift Testing

### DIFF
--- a/Tests/SwiftSyntaxSugarTests/VariableDeclSyntax/VariableDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/VariableDeclSyntax/VariableDeclSyntax_AccessLevelTests.swift
@@ -6,10 +6,10 @@
 //
 
 import SwiftSyntax
-import XCTest
+import Testing
 @testable import SwiftSyntaxSugar
 
-final class VariableDeclSyntax_AccessLevelTests: XCTestCase {
+struct VariableDeclSyntax_AccessLevelTests {
 
     // MARK: Typealiases
 
@@ -17,64 +17,65 @@ final class VariableDeclSyntax_AccessLevelTests: XCTestCase {
 
     // MARK: Access Level Tests
 
-    func testAccessLevelWithExplicitAccessLevels() {
-        for accessLevel in AccessLevelSyntax.allCases {
-            let sut = SUT(
-                modifiers: DeclModifierListSyntax { accessLevel.modifier },
-                .var,
-                name: "sut"
-            )
+    @Test(arguments: AccessLevelSyntax.allCases)
+    func accessLevelWithExplicitAccessLevelModifier(
+        from accessLevel: AccessLevelSyntax
+    ) {
+        let sut = SUT(
+            modifiers: DeclModifierListSyntax { accessLevel.modifier },
+            .var,
+            name: "sut"
+        )
 
-            XCTAssertEqual(sut.accessLevel, accessLevel)
-        }
+        #expect(sut.accessLevel == accessLevel)
     }
 
-    func testAccessLevelWithImplicitInternalAccessLevel() {
+    @Test
+    func accessLevelWithImplicitInternalAccessLevelModifier() {
         let sut = SUT(.var, name: "sut")
 
-        XCTAssertEqual(sut.accessLevel, .internal)
+        #expect(sut.accessLevel == .internal)
     }
 
     // MARK: With Access Level Tests
 
-    func testWithAccessLevelWithExplicitAccessLevels() throws {
-        for oldAccessLevel in AccessLevelSyntax.allCases {
-            for newAccessLevel in AccessLevelSyntax.allCases {
-                let sut = try SUT(
-                    modifiers: DeclModifierListSyntax {
-                        oldAccessLevel.modifier
-                        DeclModifierSyntax(name: .keyword(.static))
-                    },
-                    .var,
-                    name: "sut"
-                )
-                .withAccessLevel(newAccessLevel)
+    @Test(arguments: AccessLevelSyntax.allCases, AccessLevelSyntax.allCases)
+    func withAccessLevelWithExplicitAccessLevelModifier(
+        oldAccessLevel: AccessLevelSyntax,
+        newAccessLevel: AccessLevelSyntax
+    ) throws {
+        let sut = try SUT(
+            modifiers: DeclModifierListSyntax {
+                oldAccessLevel.modifier
+                DeclModifierSyntax(name: .keyword(.static))
+            },
+            .var,
+            name: "sut"
+        )
+        .withAccessLevel(newAccessLevel)
 
-                XCTAssertEqual(sut.accessLevel, newAccessLevel)
-                XCTAssertEqual(
-                    sut.modifiers.count,
-                    newAccessLevel == .internal ? 1 : 2
-                )
-            }
-        }
+        let expectedModifierCount = newAccessLevel == .internal ? 1 : 2
+
+        #expect(sut.accessLevel == newAccessLevel)
+        #expect(sut.modifiers.count == expectedModifierCount)
     }
 
-    func testWithAccessLevelWithImplicitInternalAccessLevel() throws {
-        for newAccessLevel in AccessLevelSyntax.allCases {
-            let sut = try SUT(
-                modifiers: DeclModifierListSyntax {
-                    DeclModifierSyntax(name: .keyword(.static))
-                },
-                .var,
-                name: "sut"
-            )
-            .withAccessLevel(newAccessLevel)
+    @Test(arguments: AccessLevelSyntax.allCases)
+    func withAccessLevelWithImplicitInternalAccessLevelModifier(
+        newAccessLevel: AccessLevelSyntax
+    ) throws {
+        let sut = try SUT(
+            modifiers: DeclModifierListSyntax {
+                DeclModifierSyntax(name: .keyword(.static))
+            },
+            .var,
+            name: "sut"
+        )
+        .withAccessLevel(newAccessLevel)
 
-            XCTAssertEqual(sut.accessLevel, newAccessLevel)
-            XCTAssertEqual(
-                sut.modifiers.count,
-                newAccessLevel == .internal ? 1 : 2
-            )
-        }
+        let expectedModifierCount = newAccessLevel == .internal ? 1 : 2
+
+        #expect(sut.accessLevel == newAccessLevel)
+        #expect(sut.modifiers.count == expectedModifierCount)
     }
 }


### PR DESCRIPTION
## Summary
- Converted `VariableDeclSyntax_AccessLevelTests` to Swift Testing.