### PR TITLE
Add SyntaxProtocol.with methods that use AttributeListBuilder

### DIFF
--- a/Sources/SwiftSyntaxSugar/AccessLevelSyntax/AccessLevelSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/AccessLevelSyntax/AccessLevelSyntax.swift
@@ -2,7 +2,7 @@
 //  AccessLevelSyntax.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/AccessorBlockSyntax/AccessorBlockSyntax+Accessors.swift
+++ b/Sources/SwiftSyntaxSugar/AccessorBlockSyntax/AccessorBlockSyntax+Accessors.swift
@@ -2,7 +2,7 @@
 //  AccessorBlockSyntax+Accessors.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/AccessorDeclSyntax/AccessorDeclSyntax+Effects.swift
+++ b/Sources/SwiftSyntaxSugar/AccessorDeclSyntax/AccessorDeclSyntax+Effects.swift
@@ -2,7 +2,7 @@
 //  AccessorDeclSyntax+Effects.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ClassDeclSyntax/ClassDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/ClassDeclSyntax/ClassDeclSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  ClassDeclSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/DeclModifierListSyntax/DeclModifierListSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/DeclModifierListSyntax/DeclModifierListSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  DeclModifierListSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/DeclModifierSyntax/DeclModifierSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/DeclModifierSyntax/DeclModifierSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  DeclModifierSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  FunctionDeclSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Effects.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Effects.swift
@@ -2,7 +2,7 @@
 //  FunctionDeclSyntax+Effects.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Parameters.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+Parameters.swift
@@ -2,7 +2,7 @@
 //  FunctionDeclSyntax+Parameters.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+ToFunctionTypeSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionDeclSyntax/FunctionDeclSyntax+ToFunctionTypeSyntax.swift
@@ -2,7 +2,7 @@
 //  FunctionDeclSyntax+ToFunctionTypeSyntax.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/FunctionParameterListSyntax/FunctionParameterListSyntax+ToTupleTypeSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionParameterListSyntax/FunctionParameterListSyntax+ToTupleTypeSyntax.swift
@@ -2,7 +2,7 @@
 //  FunctionParameterListSyntax+ToTupleTypeSyntax.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/FunctionParameterSyntax/FunctionParameterSyntax+IsVariadic.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionParameterSyntax/FunctionParameterSyntax+IsVariadic.swift
@@ -2,7 +2,7 @@
 //  FunctionParameterSyntax+IsVariadic.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/FunctionTypeSyntax/FunctionTypeSyntax+Escaping.swift
+++ b/Sources/SwiftSyntaxSugar/FunctionTypeSyntax/FunctionTypeSyntax+Escaping.swift
@@ -2,7 +2,7 @@
 //  FunctionTypeSyntax+Escaping.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/InheritedTypeListSyntax/InheritedTypeListSyntax+IdentifierTypes.swift
+++ b/Sources/SwiftSyntaxSugar/InheritedTypeListSyntax/InheritedTypeListSyntax+IdentifierTypes.swift
@@ -2,7 +2,7 @@
 //  InheritedTypeListSyntax+IdentifierTypes.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/InitializerDeclSyntax/InitializerDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/InitializerDeclSyntax/InitializerDeclSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  InitializerDeclSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Actor.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Actor.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax+Actor.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+AssociatedTypes.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+AssociatedTypes.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax+AssociatedTypes.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Functions.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Functions.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax+Functions.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+GenericWhereClauses.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+GenericWhereClauses.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax+GenericWhereClauses.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Initializers.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Initializers.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax+Initializers.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Type.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Type.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax+Type.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Variables.swift
+++ b/Sources/SwiftSyntaxSugar/ProtocolDeclSyntax/ProtocolDeclSyntax+Variables.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax+Variables.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithAttributeListSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithAttributeListSyntax.swift
@@ -1,8 +1,8 @@
 //
 //  SyntaxProtocol+WithAttributeListSyntax.swift
-//  SwiftSyntaxSugar
 //
-//  Created by Gray Campbell on 1/14/25.
+//  Created by Gray Campbell.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithCodeBlockSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithCodeBlockSyntax.swift
@@ -2,7 +2,7 @@
 //  SyntaxProtocol+WithCodeBlockSyntax.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithDeclModifierListSyntax.swift
+++ b/Sources/SwiftSyntaxSugar/SyntaxProtocol/SyntaxProtocol+WithDeclModifierListSyntax.swift
@@ -2,7 +2,7 @@
 //  SyntaxProtocol+WithDeclModifierListSyntax.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/TypeSyntax/TypeSyntax+Describing.swift
+++ b/Sources/SwiftSyntaxSugar/TypeSyntax/TypeSyntax+Describing.swift
@@ -2,7 +2,7 @@
 //  TypeSyntax+Describing.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/VariableDeclSyntax/VariableDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/VariableDeclSyntax/VariableDeclSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  VariableDeclSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/AccessLevelSyntax/AccessLevelSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/AccessLevelSyntax/AccessLevelSyntaxTests.swift
@@ -2,7 +2,7 @@
 //  AccessLevelSyntaxTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/AccessorBlockSyntax/AccessorBlockSyntax_AccessorsTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/AccessorBlockSyntax/AccessorBlockSyntax_AccessorsTests.swift
@@ -2,7 +2,7 @@
 //  AccessorBlockSyntax_AccessorsTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/AccessorDeclSyntax/AccessorDeclSyntax_EffectsTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/AccessorDeclSyntax/AccessorDeclSyntax_EffectsTests.swift
@@ -2,7 +2,7 @@
 //  AccessorDeclSyntax_EffectsTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ClassDeclSyntax/ClassDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ClassDeclSyntax/ClassDeclSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  ClassDeclSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/DeclModifierListSyntax/DeclModifierListSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/DeclModifierListSyntax/DeclModifierListSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  DeclModifierListSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/DeclModifierSyntax/DeclModifierSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/DeclModifierSyntax/DeclModifierSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  DeclModifierSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  FunctionDeclSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_EffectsTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_EffectsTests.swift
@@ -2,7 +2,7 @@
 //  FunctionDeclSyntax_EffectsTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ParametersTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ParametersTests.swift
@@ -2,7 +2,7 @@
 //  FunctionDeclSyntax_ParametersTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ToFunctionTypeSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionDeclSyntax/FunctionDeclSyntax_ToFunctionTypeSyntaxTests.swift
@@ -2,7 +2,7 @@
 //  FunctionDeclSyntax_ToFunctionTypeSyntaxTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/FunctionParameterListSyntax/FunctionParameterListSyntax_ToTupleTypeSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionParameterListSyntax/FunctionParameterListSyntax_ToTupleTypeSyntaxTests.swift
@@ -2,7 +2,7 @@
 //  FunctionParameterListSyntax_ToTupleTypeSyntaxTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/FunctionParameterSyntax/FunctionParameterSyntax_IsVariadicTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionParameterSyntax/FunctionParameterSyntax_IsVariadicTests.swift
@@ -2,7 +2,7 @@
 //  FunctionParameterSyntax_IsVariadicTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/FunctionTypeSyntax/FunctionTypeSyntax_EscapingTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/FunctionTypeSyntax/FunctionTypeSyntax_EscapingTests.swift
@@ -2,7 +2,7 @@
 //  FunctionTypeSyntax_EscapingTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/InheritedTypeListSyntax/InheritedTypeListSyntax_IdentifierTypesTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/InheritedTypeListSyntax/InheritedTypeListSyntax_IdentifierTypesTests.swift
@@ -2,7 +2,7 @@
 //  InheritedTypeListSyntax_IdentifierTypesTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/InitializerDeclSyntax/InitializerDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/InitializerDeclSyntax/InitializerDeclSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  InitializerDeclSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_ActorTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_ActorTests.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax_ActorTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_AssociatedTypesTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_AssociatedTypesTests.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax_AssociatedTypesTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_FunctionsTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_FunctionsTests.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax_FunctionsTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_GenericWhereClausesTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_GenericWhereClausesTests.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax_GenericWhereClausesTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_InitializersTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_InitializersTests.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax_InitializersTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_TypeTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_TypeTests.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax_TypeTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_VariablesTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ProtocolDeclSyntax/ProtocolDeclSyntax_VariablesTests.swift
@@ -2,7 +2,7 @@
 //  ProtocolDeclSyntax_VariablesTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithAttributeListSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithAttributeListSyntaxTests.swift
@@ -1,8 +1,8 @@
 //
 //  SyntaxProtocol_WithAttributeListSyntaxTests.swift
-//  SwiftSyntaxSugar
 //
-//  Created by Gray Campbell on 1/14/25.
+//  Created by Gray Campbell.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithCodeBlockSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithCodeBlockSyntaxTests.swift
@@ -2,7 +2,7 @@
 //  SyntaxProtocol_WithCodeBlockSyntaxTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithDeclModifierListSyntaxTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/SyntaxProtocol/SyntaxProtocol_WithDeclModifierListSyntaxTests.swift
@@ -2,7 +2,7 @@
 //  SyntaxProtocol_WithDeclModifierListSyntaxTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/TypeSyntax/TypeSyntax_DescribingTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/TypeSyntax/TypeSyntax_DescribingTests.swift
@@ -2,7 +2,7 @@
 //  TypeSyntax_DescribingTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/VariableDeclSyntax/VariableDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/VariableDeclSyntax/VariableDeclSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  VariableDeclSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax


### PR DESCRIPTION
## Summary
- Added `SyntaxProtocol.with` methods that use `AttributeListBuilder` for cleaner modification of a syntax's attributes.
- Added unit tests.
- Ran `swiftformat`.