### PR TITLE
Add accessLevel property to ActorDeclSyntax and StructDeclSyntax

### DIFF
--- a/Sources/SwiftSyntaxSugar/ActorDeclSyntax/ActorDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/ActorDeclSyntax/ActorDeclSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  ActorDeclSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Sources/SwiftSyntaxSugar/StructDeclSyntax/StructDeclSyntax+AccessLevel.swift
+++ b/Sources/SwiftSyntaxSugar/StructDeclSyntax/StructDeclSyntax+AccessLevel.swift
@@ -2,7 +2,7 @@
 //  StructDeclSyntax+AccessLevel.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 public import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/ActorDeclSyntax/ActorDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/ActorDeclSyntax/ActorDeclSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  ActorDeclSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax

--- a/Tests/SwiftSyntaxSugarTests/StructDeclSyntax/StructDeclSyntax_AccessLevelTests.swift
+++ b/Tests/SwiftSyntaxSugarTests/StructDeclSyntax/StructDeclSyntax_AccessLevelTests.swift
@@ -2,7 +2,7 @@
 //  StructDeclSyntax_AccessLevelTests.swift
 //
 //  Created by Gray Campbell.
-//  Copyright © 2024 Fetch.
+//  Copyright © 2025 Fetch.
 //
 
 import SwiftSyntax


### PR DESCRIPTION
## Summary
- Added `accessLevel` property to `ActorDeclSyntax` and `StructDeclSyntax`.