### PR TITLE
Add Homebrew and SwiftFormat guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ brew bundle
 
 This project uses [`SwiftFormat`](https://github.com/nicklockwood/SwiftFormat) to maintain consistent code formatting.
 We do not currently automate the process of formatting code, but our CI workflow does use `SwiftFormat` as a linter to
-validate that all code changes adhere to our formatting rules. Before creating a PR, please run `SwiftFormat` on all new 
+validate that all code changes adhere to our formatting rules. Before creating a PR, please run `swiftformat` on all new 
 or updated files and commit the changes.
 
 ## Signed Commits Required


### PR DESCRIPTION
## Summary

- Added `Homebrew` and `SwiftFormat` guidelines to `CONTRIBUTING.md`.